### PR TITLE
Upgrade xalan 2.7.3 that contains bcel 6.7.0

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997-2023 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -402,7 +402,7 @@
         <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.3</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Apache Commons BCEL 6.6.0 addressed CVE-2022-42920. CVE-2022-42920 is a publicly reported vulnerability. The CVSS v3.1 score in NVD is 9.8. Apache Commons BCEL has a number of APIs that would normally only allow changing specific class characteristics.

Current version of JSTL-API version, that depends on xalan 2.7.2, contains a shaded BCEL 6.6.0.